### PR TITLE
About fix

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -45,7 +45,7 @@
     <include src="./partials/footer.html"></include>
 
     <!-- Зразок кнопок -->
-    <!-- <include src="./partials/components/button.html"></include> -->
+    <include src="./partials/components/button.html"></include>
     <include src="./partials/components/modal-btn.html"></include>
     <include src="./partials/components/popap.html"></include>
     <!-- <include src="./partials/components/mail-form.html"></include> -->

--- a/src/partials/about.html
+++ b/src/partials/about.html
@@ -45,7 +45,7 @@
                         Aliquam erat volutpat. Aenean accumsan.
                         </p>
                     
-                        <button class="white-button about__button js-open-modal" data-modal="2">Read more
+                        <button class="button--white about__button js-open-modal" data-modal="about-modal">Read more
                             <svg class="button__icon" width="7px" height="10px">
                                 <use href="./images/icons.svg#icon-white-button"></use>
                             </svg>

--- a/src/partials/components/about-modal.html
+++ b/src/partials/components/about-modal.html
@@ -1,5 +1,5 @@
 <!-- Модалка about-->
-<div class="modal about-modal" data-modal="2">
+<div class="modal about-modal" data-modal="about-modal">
     <!--   Svg иконка для закрытия окна  -->
     <svg class="modal__cross js-modal-close" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
         <path

--- a/src/partials/components/button.html
+++ b/src/partials/components/button.html
@@ -1,29 +1,44 @@
 <div class="container">
     <div class="section">
-        <h2>Зразок кнопок для тегу button, special для команди</h2>
+        <h2>Зразок кнопок для тегу button</h2>
         
-        <p>Щоб використати оформлення додайте кнопці клас "red-button" або "white-button"</p>
+        <p>Щоб використати колір і анімацію ховера додайте клас button--red чи button--white
+            <br>
+            <br>
+            Для задавання margin, pading, border-radius, font-size, line-height та іншого використовуйте унікальний клас для вашої секції, наприклад about__button
+            <br>
+            <br>
+            Також доступний плейсхолдер саме для кнопки (не лінка)
+            <pre>
+                %button{
+                font-family: inherit;
+                border-radius: 22px;
+                padding: 12px 37px 11px 37px;
+                }
+            </pre>
+            Щоб використати - вставте @extend %button;
+<br>
+<br>
+        </p>
         
+        <button class="about__button button--red">Read more</button>
+        <button class="about__button button--white">Read more</button>
         
-        <button class="red-button">Read more</button>
-        <button class="white-button">Read more</button>
-        
-        <h3>Щоб отримати кнопки зі стрілками додайте всередину button тег SVG з класом "button__icon" та use з посиланням</h3>
+        <h3>Щоб отримати кнопки зі стрілками додайте всередину button тег SVG з атрибутами class="button__icon" width="7px" height="10px" та use з посиланням</h3>
         <p>use href="./images/icons.svg#icon-red-button"</p>
+        <p>або</p>
         <p>use href="./images/icons.svg#icon-white-button"</p>
         
-        <button class="red-button">Read more
+        <button class="about__button button--red">Read more
             <svg class="button__icon" width="7px" height="10px">
                 <use href="./images/icons.svg#icon-red-button"></use>
             </svg>
         </button>
         
-        <button class="white-button">Read more
+        <button class="about__button button--white">Read more
             <svg class="button__icon" width="7px" height="10px">
                 <use href="./images/icons.svg#icon-white-button"></use>
             </svg>
         </button>
-
-        <p>Щоб задати свої налаштування (наприклад щоб перебити pading) - додайте в тег button свій унікальний клас, до прикладу class="red-button about__button"</p>
     </div>
 </div>

--- a/src/partials/components/modal-btn.html
+++ b/src/partials/components/modal-btn.html
@@ -1,9 +1,20 @@
 <section class="section  modaltest">
   <div class="section container flex-btn">
-    <button class="red-button js-open-modal" data-modal="1">modal 1</button>
-    <button class="red-button js-open-modal" data-modal="2">modal 2</button>
-    <button class="red-button js-open-modal" data-modal="5">modal 5</button>
-    <button class="red-button js-open-modal" data-modal="6">modal 6</button>
+    <p>Розібрався з модалками, як працює там JS
+    
+    Коротше кажучи, коли JS код бачить атрибут data-modal=“1”, він забирає з контексту цю одиничку (1) і шукає модальне
+    вікно з таким же атрибутом data-modal=“1”.
+    
+    Коду всерівно чи там є 1 чи слово ice-cream, головне, щоб значення data-modal співпадали як на кнопці, так і на div
+    модалки.
+    
+    Кожен може дати data-modal свою унікальну назву, до прикладу у мене data-modal=“about-modal”, яку задати однаково на
+    кнопку і на модалку своєї секції.</p>
+    <p>(message form Rostyslav)</p>
+    <button class="about__button button--red js-open-modal" data-modal="1">modal 1</button>
+    <button class="about__button button--white js-open-modal" data-modal="2">modal 2</button>
+    <button class="about__button button--red js-open-modal" data-modal="5">modal 5</button>
+    <button class="about__button button--white js-open-modal" data-modal="6">modal 6</button>
 
     <a href="#" class="js-open-modal" data-modal="3">Открыть окно 3</a>
   </div>

--- a/src/sass/components/_about.scss
+++ b/src/sass/components/_about.scss
@@ -146,7 +146,8 @@ background-size: contain;
           }
 }
 
-.white-button.about__button{
+.about__button{
+  @extend %button;
     margin-top: 20px;
 
     font-weight: 700;
@@ -158,6 +159,8 @@ background-size: contain;
           font-size: 16px;
           line-height: 1.31;
       } 
+
+      
 }
 
 // Модалка

--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -1,6 +1,5 @@
-
-.red-button{
-    @extend %button;
+//Button color style only
+.button--red{
     @extend %trans;
 
     color: $red-btn-txt;
@@ -13,8 +12,7 @@
 }
 
 
-.white-button{
-    @extend %button;
+.button--white{
     @extend %trans;
    
     color: $white-btn-txt;
@@ -25,6 +23,8 @@
             background-color: $white-btn-bgc--active;
         }
     }
+
+
 
 .button__icon{
     margin-left: 13px;


### PR DESCRIPTION
Змінив кнопки по БЕМу.

Якщо не проти, для наглядності, увімкнув відображення прикладу як все робити на загальній сторінці.
Перед фінальною перевіркою видалимо

Вніс пояснення щодо модалок.

Окрім того підмітив:
-header на розрішенні 320 дає flex, який все руйнує
-Pading в кнопках hero замалі, замість бокових 14px (right&left)
 має бути 
23px для Products 
і 20px для How it`s made



